### PR TITLE
Implemented method that obtain the internal reference of the React component.

### DIFF
--- a/src/resolvers/Vue.ts
+++ b/src/resolvers/Vue.ts
@@ -20,6 +20,11 @@ export default function VueResolver<T>(component: (props: T) => any) {
         (this as any).$slots.default
       );
     },
+    methods: {
+      reactRef() {
+          return this.$children[0].reactComponentRef.reactRef.current;
+      }
+    },
   } as unknown as
     | Component<any, any, any, T>
     | AsyncComponent<any, any, any, T>;

--- a/src/wrappers/ReactWrapper.tsx
+++ b/src/wrappers/ReactWrapper.tsx
@@ -126,6 +126,8 @@ export const ReactWrapper = {
     }
   },
   reactRef() : any {
+    // TODO: any reference to the inner React component will break the type (user could force it himself)
+    // but there might be a way to make it generic, since we do receive the component as a function argument
     return (this as any).reactComponentRef;
   },
   inheritAttrs: false,

--- a/src/wrappers/ReactWrapper.tsx
+++ b/src/wrappers/ReactWrapper.tsx
@@ -5,12 +5,20 @@ import { v4 } from "uuid";
 
 const makeReactContainer = (Component: any) =>
   class ReactInVue extends React.Component {
+
+    public reactRef : React.RefObject<unknown>;
+
     static displayName = `ReactInVue${
       Component.displayName || Component.name || "Component"
     }`;
 
     constructor(props: any) {
       super(props);
+
+      /**
+       * Attach internal reference, so calls to child methods are allowed.
+       */
+      this.reactRef = React.createRef();
 
       /**
        * We create a stateful component in order to attach a ref on it. We will use that ref to
@@ -51,7 +59,7 @@ const makeReactContainer = (Component: any) =>
       // console.log("wrappedChildren: ", wrappedChildren);
 
       return (
-        <Component {...rest}>
+        <Component ref={this.reactRef} {...rest}>
           {wrappedChildren && <VueWrapperRender component={wrappedChildren} />}
         </Component>
       );
@@ -116,6 +124,9 @@ export const ReactWrapper = {
     } else {
       (this as any).reactComponentRef.setState({ children: null });
     }
+  },
+  reactRef() : any {
+    return (this as any).reactComponentRef;
   },
   inheritAttrs: false,
   watch: {


### PR DESCRIPTION
Actually is not possible to call React components methods from Vue, because the internal reference bind to the React component is missing. I implemented a way to obtain the internal reference calling the "reactRef" method.

Example:

```vue
<template>
<div>
    <MyReactComp ref="myReactComp" />
    <button type="button" @click="$refs.myReactComp.reactRef().reactMethodFooBar()">Call React Method</button>
</div>
</template>

<script>
import { ReactInVue } from "vuera-ts";
import { ReactComp } from "./ReactComp";

const MyReactComp = ReactInVue(MyReactComp);

export default {
  name: "VueApp",
};
</script>
```